### PR TITLE
Switch to user namespaced workflows

### DIFF
--- a/workflows/tests.py
+++ b/workflows/tests.py
@@ -1,4 +1,7 @@
+import io
+
 from django.contrib.auth.models import User
+from django.http.response import FileResponse
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -6,13 +9,14 @@ from rest_framework.test import APITestCase
 
 class WorkflowTests(APITestCase):
     def setUp(self) -> None:
-        User.objects.create(username="admin")
+        User.objects.create(username="user1")
+        User.objects.create(username="user2")
 
     def test_create(self) -> None:
-        create_url = reverse("workflows:workflow-list")
-        user = User.objects.filter(username="admin").first()
+        user = User.objects.filter(username="user1").first()
         assert not user is None
 
+        create_url = reverse("workflows:workflow-list", args=[user.username])
         workflow_file = open("example-assets/workflows/hello-world.cwl", "r")
         self.client.force_authenticate(user)
         response = self.client.post(
@@ -24,6 +28,55 @@ class WorkflowTests(APITestCase):
         )
         assert response.status_code == status.HTTP_201_CREATED
 
-        workflow_url = reverse("workflows:workflow-list")
-        list_resp = self.client.get(workflow_url)
+        list_url = reverse("workflows:workflow-list", args=[user.username])
+        list_resp = self.client.get(list_url)
         assert list_resp.json()[0]["name"] == "hello-world"
+
+    def test_workflow_namespacing(self) -> None:
+        user = User.objects.filter(username="user1").first()
+        assert not user is None
+        create_url = reverse("workflows:workflow-list", args=[user.username])
+        workflow_file = open("example-assets/workflows/hello-world.cwl", "r")
+        self.client.force_authenticate(user)
+        response = self.client.post(
+            create_url,
+            data={
+                "name": "hello-world",
+                "file": workflow_file,
+            },
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+
+        other_user = User.objects.filter(username="user2").first()
+        assert not other_user is None
+
+        self.client.force_authenticate(other_user)
+        list_url = reverse("workflows:workflow-list", args=[other_user.username])
+        list_resp = self.client.get(list_url)
+        assert len(list_resp.json()) == 0
+
+    def test_workflow_file(self) -> None:
+        user = User.objects.filter(username="user1").first()
+        assert not user is None
+
+        create_url = reverse("workflows:workflow-list", args=[user.username])
+        self.client.force_authenticate(user)
+        with open("example-assets/workflows/hello-world.cwl", "r") as workflow_file:
+            response = self.client.post(
+                create_url,
+                data={
+                    "name": "hello-world",
+                    "file": workflow_file,
+                },
+            )
+        assert response.status_code == status.HTTP_201_CREATED
+
+        file_url = reverse(
+            "workflows:workflow-file", args=[user.username, "hello-world"]
+        )
+        file_response: FileResponse = self.client.get(file_url)
+        file_str = b""
+        for chunk in file_response.streaming_content:
+            file_str += chunk
+        with open("example-assets/workflows/hello-world.cwl", "rb") as workflow_file:
+            assert file_str == workflow_file.read()

--- a/workflows/urls.py
+++ b/workflows/urls.py
@@ -4,7 +4,17 @@ from rest_framework.routers import DefaultRouter
 
 from workflows import views
 
-router = DefaultRouter()
-router.register("workflows", views.WorkflowViewSet, basename="workflow")
 
-urlpatterns = router.urls
+urlpatterns = [
+    path("<str:user_id>/workflows", views.WorkflowList.as_view(), name="workflow-list"),
+    path(
+        "<str:user_id>/workflows/<str:workflow_id>/",
+        views.WorkflowDetail.as_view(),
+        name="workflow-detail",
+    ),
+    path(
+        "<str:user_id>/workflows/<str:workflow_id>/workflow",
+        views.WorkflowFile.as_view(),
+        name="workflow-file",
+    ),
+]


### PR DESCRIPTION
Rearrange the url scheme so that it's now `<base>/<username>/workflows/` to allow users to have separate workflows. The change url scheme isn't explicitly necessary but if we're planning to support the concept of public and non-public workflows, I think this fits better for that.

I also made some more tests around adding and retrieving workflows.