### PR TITLE
Add support for stdout and stderr endpoints from toil

### DIFF
--- a/freva/settings.py
+++ b/freva/settings.py
@@ -27,7 +27,7 @@ SECRET_KEY = "django-insecure-9q_cy#5uj!4=q#xeh(!jhrosb_z%b1g863ba8&mgcygly+hvk!
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS: list[str] = ["freva"]
+ALLOWED_HOSTS: list[str] = ["freva", "localhost"]
 
 
 # Application definition

--- a/runs/urls.py
+++ b/runs/urls.py
@@ -1,9 +1,16 @@
 from django.contrib import admin
-from rest_framework.routers import DefaultRouter
+from django.urls import include, path
 
 from runs import views
 
-router = DefaultRouter()
-router.register("runs", views.RunViewSet, basename="runs")
-
-urlpatterns = router.urls
+urlpatterns = [
+    path("runs/", views.RunList.as_view(), name="run-list"),
+    path(
+        "runs/<str:run_id>/",
+        views.RunDetail.as_view(),
+        name="run-detail",
+    ),
+    path("runs/<str:run_id>/status", views.RunStatus.as_view(), name="run-status"),
+    path("runs/<str:run_id>/stdout", views.RunStdout.as_view(), name="run-stdout"),
+    path("runs/<str:run_id>/stderr", views.RunStderr.as_view(), name="run-stderr"),
+]

--- a/runs/views.py
+++ b/runs/views.py
@@ -1,17 +1,15 @@
 from typing import TYPE_CHECKING, Sequence
 
 from rest_framework import status
-from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound
 from rest_framework.parsers import JSONParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.viewsets import ViewSet
 from rest_framework.views import APIView
 
 from freva import settings
-from toil.client import RunWorkflow, ToilClient
+from toil.client import ToilClient
 from workflows.models import Workflow
 
 from .models import Run


### PR DESCRIPTION
Toil has some endpoints to get its `stdout` and `stderr` for tasks which aren't part of the GA4GH spec. This adds some endpoints to proxy to them so Freva can show this info as well.

I also added `localhost` to the allowed hosts.